### PR TITLE
Disable pod disruption budgets on CNPG clusters in dev and staging

### DIFF
--- a/litellm.tf
+++ b/litellm.tf
@@ -46,6 +46,7 @@ resource "kubectl_manifest" "litellm_db_deployment" {
       storage = {
         size = "10Gi"
       }
+      enablePDB = contains(["dev", "staging"], var.environment) ? false : true
     }
   })
 

--- a/openwebui.tf
+++ b/openwebui.tf
@@ -241,6 +241,7 @@ resource "kubectl_manifest" "openwebui_db_deployment" {
       storage = {
         size = "10Gi"
       }
+      enablePDB = contains(["dev", "staging"], var.environment) ? false : true
     }
   })
 


### PR DESCRIPTION
- Disable pod disruption budget on cnpg postgres clusters to enable Kubernetes maintenance window upgrades