### PR TITLE
added  functionality for drop_params

### DIFF
--- a/litellm.tf
+++ b/litellm.tf
@@ -18,6 +18,7 @@ locals {
     "proxy_config.litellm_settings.json_logs"                        = var.litellm_proxy_json_logs
     "proxy_config.litellm_settings.request_timeout"                  = var.litellm_proxy_request_timeout
     "proxy_config.litellm_settings.set_verbose"                      = var.litellm_proxy_set_verbose
+    "proxy_config.litellm_settings.drop_params"                      = var.litellm_proxy_drop_params
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -125,10 +125,17 @@ variable "litellm_proxy_request_timeout" {
   default     = 600
 }
 
+
 variable "litellm_proxy_set_verbose" {
   description = "Set verbose logging"
   type        = bool
   default     = false
+}
+
+variable "litellm_proxy_drop_params" {
+  description = "Drop params for models that can't support them"
+  type        = bool
+  default     = true
 }
 
 variable "litellm_image_tag" {


### PR DESCRIPTION
This helps address the situation when an API client of the instance uses OpenAI API parameters that are not supported by the target model.  Basically tells LiteLLM that it's ok to drop them as needed.

See https://docs.litellm.ai/docs/completion/drop_params#openai-proxy-usage for more details.

I've tested this with a local instance of the tfmod on soren-chat.dev.tamu.ai using Msty as the API client.

